### PR TITLE
Accounting for provider key change

### DIFF
--- a/src/variables/VideoEmbedderVariable.php
+++ b/src/variables/VideoEmbedderVariable.php
@@ -110,7 +110,8 @@ class VideoEmbedderVariable
      * 
     **/
     public function getProviderName($url) {
-        return Template::raw(VideoEmbedder::$plugin->service->getInfo($url)->providerName);
+        $provider = VideoEmbedder::$plugin->service->getInfo($url)->providerName ?? VideoEmbedder::$plugin->service->getInfo($url)->provider_name;
+        return Template::raw($provider);
     }
 
     /**


### PR DESCRIPTION
I'm not sure why, but the provider key is provider_name, not providerName for me. Updating to allow for both keys. 

```
Undefined property: stdClass::$providerName
```